### PR TITLE
Server side event handling improvements

### DIFF
--- a/HomeRunTracker.Backend/Grains/GameGrain.cs
+++ b/HomeRunTracker.Backend/Grains/GameGrain.cs
@@ -23,7 +23,6 @@ public class GameGrain : Grain, IGameGrain
     private int _gameId;
     private bool _isInitialLoad = true;
 
-    // TODO: attach the game start time on each home run notification and home run update notification
     public GameGrain(ILogger<GameGrain> logger, IMediator mediator, IHttpService httpService,
         LeverageIndexService leverageIndexService)
     {

--- a/HomeRunTracker.Backend/Grains/GameGrain.cs
+++ b/HomeRunTracker.Backend/Grains/GameGrain.cs
@@ -23,6 +23,7 @@ public class GameGrain : Grain, IGameGrain
     private int _gameId;
     private bool _isInitialLoad = true;
 
+    // TODO: attach the game start time on each home run notification and home run update notification
     public GameGrain(ILogger<GameGrain> logger, IMediator mediator, IHttpService httpService,
         LeverageIndexService leverageIndexService)
     {
@@ -162,7 +163,8 @@ public class GameGrain : Grain, IGameGrain
             existingHomeRun.HighlightUrl = highlightUrl;
             if (!_isInitialLoad)
             {
-                await _mediator.Publish(new HomeRunUpdatedNotification(descriptionHashString, _gameId, highlightUrl));
+                await _mediator.Publish(new HomeRunUpdatedNotification(descriptionHashString, _gameId,
+                    _gameDetails.GameData.GameDateTime.DateTime, highlightUrl));
             }
 
             return;
@@ -201,7 +203,7 @@ public class GameGrain : Grain, IGameGrain
         _homeRuns.Add(homeRunRecord);
         if (!_isInitialLoad)
         {
-            await _mediator.Publish(new HomeRunNotification(_gameId, homeRunRecord));
+            await _mediator.Publish(new HomeRunNotification(_gameId, _gameDetails.GameData.GameDateTime.DateTime, homeRunRecord));
         }
     }
 }

--- a/HomeRunTracker.Backend/Grains/GameListGrain.cs
+++ b/HomeRunTracker.Backend/Grains/GameListGrain.cs
@@ -78,7 +78,7 @@ public class GameListGrain : Grain, IGameListGrain
         _logger.LogInformation("Publishing home run {Hash} for game {GameId}", notification.HomeRun.Hash,
             notification.GameId.ToString());
 
-        await _hubContext.Clients.All.SendAsync("ReceiveHomeRun", JsonConvert.SerializeObject(notification.HomeRun));
+        await _hubContext.Clients.All.SendAsync("ReceiveHomeRun", JsonConvert.SerializeObject(notification));
 
         _logger.LogInformation("Finished publishing home run {Hash} for game {GameId}", notification.HomeRun.Hash,
             notification.GameId.ToString());

--- a/HomeRunTracker.Backend/Hubs/HomeRunHub.cs
+++ b/HomeRunTracker.Backend/Hubs/HomeRunHub.cs
@@ -1,4 +1,4 @@
-﻿using HomeRunTracker.Common.Models.Internal;
+﻿using HomeRunTracker.Common.Models.Notifications;
 using Microsoft.AspNetCore.SignalR;
 using Newtonsoft.Json;
 
@@ -6,8 +6,8 @@ namespace HomeRunTracker.Backend.Hubs;
 
 public class HomeRunHub : Hub
 {
-    public async Task PublishHomeRunAsync(HomeRunRecord homeRun)
+    public async Task PublishHomeRunAsync(HomeRunNotification homeRunNotification)
     {
-        await Clients.All.SendAsync("ReceiveHomeRun", JsonConvert.SerializeObject(homeRun));
+        await Clients.All.SendAsync("ReceiveHomeRun", JsonConvert.SerializeObject(homeRunNotification));
     }
 }

--- a/HomeRunTracker.Common/Models/Details/GameData.cs
+++ b/HomeRunTracker.Common/Models/Details/GameData.cs
@@ -12,4 +12,8 @@ public class GameData
     [JsonProperty("teams")]
     [Id(1)]
     public TeamMatchup TeamMatchup { get; set; } = new();
+    
+    [JsonProperty("datetime")]
+    [Id(2)]
+    public GameDateTime GameDateTime { get; set; } = new();
 }

--- a/HomeRunTracker.Common/Models/Details/GameDateTime.cs
+++ b/HomeRunTracker.Common/Models/Details/GameDateTime.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace HomeRunTracker.Common.Models.Details;
+
+[GenerateSerializer]
+public class GameDateTime
+{
+    [JsonProperty("dateTime")]
+    [Id(0)]
+    public DateTime DateTime { get; set; }
+}

--- a/HomeRunTracker.Common/Models/Notifications/HomeRunNotification.cs
+++ b/HomeRunTracker.Common/Models/Notifications/HomeRunNotification.cs
@@ -6,15 +6,19 @@ namespace HomeRunTracker.Common.Models.Notifications;
 [GenerateSerializer]
 public class HomeRunNotification : INotification
 {
-    public HomeRunNotification(int gameId, HomeRunRecord homeRun)
+    public HomeRunNotification(int gameId, DateTime gameStartTime, HomeRunRecord homeRun)
     {
         GameId = gameId;
+        GameStartTime = gameStartTime;
         HomeRun = homeRun;
     }
 
     [Id(0)]
     public int GameId { get; }
-
+    
     [Id(1)]
+    public DateTime GameStartTime { get; }
+
+    [Id(2)]
     public HomeRunRecord HomeRun { get; }
 }

--- a/HomeRunTracker.Common/Models/Notifications/HomeRunUpdatedNotification.cs
+++ b/HomeRunTracker.Common/Models/Notifications/HomeRunUpdatedNotification.cs
@@ -5,10 +5,11 @@ namespace HomeRunTracker.Common.Models.Notifications;
 [GenerateSerializer]
 public class HomeRunUpdatedNotification : INotification
 {
-    public HomeRunUpdatedNotification(string homeRunHash, int gameId, string highlightUrl)
+    public HomeRunUpdatedNotification(string homeRunHash, int gameId, DateTime gameStartTime, string highlightUrl)
     {
         HomeRunHash = homeRunHash;
         GameId = gameId;
+        GameStartTime = gameStartTime;
         HighlightUrl = highlightUrl;
     }
 
@@ -17,7 +18,10 @@ public class HomeRunUpdatedNotification : INotification
     
     [Id(1)]
     public int GameId { get; }
-
+    
     [Id(2)]
+    public DateTime GameStartTime { get; }
+
+    [Id(3)]
     public string HighlightUrl { get; }
 }

--- a/HomeRunTracker.Frontend/Components/HomeRunTable.razor.cs
+++ b/HomeRunTracker.Frontend/Components/HomeRunTable.razor.cs
@@ -66,8 +66,9 @@ public partial class HomeRunTable
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task OnHomeRunReceived(HomeRunRecord homeRunDto)
+    private async Task OnHomeRunReceived(HomeRunNotification homeRunNotification)
     {
+        var homeRunDto = homeRunNotification.HomeRun;
         var homeRun = homeRunDto.Adapt<HomeRunModel>();
         _homeRuns.Add(homeRun);
         _items = _homeRuns.AsQueryable();

--- a/HomeRunTracker.Frontend/Services/HomeRunHubService.cs
+++ b/HomeRunTracker.Frontend/Services/HomeRunHubService.cs
@@ -1,5 +1,4 @@
-﻿using HomeRunTracker.Common.Models.Internal;
-using HomeRunTracker.Common.Models.Notifications;
+﻿using HomeRunTracker.Common.Models.Notifications;
 using Microsoft.AspNetCore.SignalR.Client;
 using Newtonsoft.Json;
 
@@ -26,7 +25,7 @@ public class HomeRunHubService
     {
         _hubConnection.On<string>("ReceiveHomeRun", json =>
         {
-            var homeRun = JsonConvert.DeserializeObject<HomeRunRecord>(json);
+            var homeRun = JsonConvert.DeserializeObject<HomeRunNotification>(json);
             if (homeRun is null)
             {
                 throw new InvalidOperationException("Home run is null");
@@ -47,7 +46,7 @@ public class HomeRunHubService
         });
     }
 
-    public event Func<HomeRunRecord, Task>? OnHomeRunReceived;
+    public event Func<HomeRunNotification, Task>? OnHomeRunReceived;
     
     public event Func<HomeRunUpdatedNotification, Task>? OnHomeRunUpdated;
 }


### PR DESCRIPTION
- Pass game start date to all home run notifications
- Always have frontend notification handlers attached, but only add home runs when the day matches